### PR TITLE
Fix strongsAvailable() function

### DIFF
--- a/index.js
+++ b/index.js
@@ -490,31 +490,23 @@ class NodeSwordInterface {
   }
 
   /**
-   * Checks whether Hebrew Strong's definitions are available
+   * Checks whether Hebrew Strong's definitions are available.
    * 
    * @return {Boolean}
    */
   hebrewStrongsAvailable() {
-    try {
-      const strongsDict = this.nativeInterface.getLocalModule("StrongsHebrew");
-      return !!strongsDict;
-    } catch (e) {
-      return false;
-    }
+    const strongsDict = this.nativeInterface.getLocalModule("StrongsHebrew");
+    return !!strongsDict;
   }
 
   /**
-   * Checks whether Greek Strong's definitions are available
+   * Checks whether Greek Strong's definitions are available.
    * 
    * @return {Boolean}
    */
   greekStrongsAvailable() {
-    try {
-      const strongsDict = this.nativeInterface.getLocalModule("StrongsGreek");
-      return !!strongsDict;
-    } catch (e) {
-      return false;
-    }
+    const strongsDict = this.nativeInterface.getLocalModule("StrongsGreek");
+    return !!strongsDict;
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -496,8 +496,8 @@ class NodeSwordInterface {
    */
   hebrewStrongsAvailable() {
     try {
-      this.nativeInterface.getLocalModule("StrongsHebrew");
-      return true;
+      const strongsDict = this.nativeInterface.getLocalModule("StrongsHebrew");
+      return !!strongsDict;
     } catch (e) {
       return false;
     }
@@ -510,8 +510,8 @@ class NodeSwordInterface {
    */
   greekStrongsAvailable() {
     try {
-      this.nativeInterface.getLocalModule("StrongsGreek");
-      return true;
+      const strongsDict = this.nativeInterface.getLocalModule("StrongsGreek");
+      return !!strongsDict;
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
Seems like right now NSI is not detecting correctly if Strongs dictionaries are not installed (see https://github.com/ezra-bible-app/ezra-bible-app/issues/404). 

This should fix it